### PR TITLE
use bottom line, clear screen on flush, works with resize

### DIFF
--- a/src/teashop.ffi.mjs
+++ b/src/teashop.ffi.mjs
@@ -498,27 +498,11 @@ class Renderer extends EventEmitter {
   #flush() {
     let new_lines = this.#lines();
     let new_lines_this_flush = new_lines.length;
-    let clear_sequence = new Array();
 
-    if (this.#lines_rendered > 0) {
-      for (let i = this.#lines_rendered; i > 0; i--) {
-        clear_sequence.push(clear_line_seq());
-        clear_sequence.push(cursor_up_seq(1));
-      }
-    }
-    // extra clear line to prevent phantom length lines
-        clear_sequence.push(clear_line_seq());
-
-    let tmp = new_lines.join("\r\n");
-    // log(clear_sequence.join("") + tmp + "\r\n" + cursor_back_seq(100));
-    print(clear_sequence.join("") + tmp + "\r\n");
+    clear();
+    print(new_lines.join("\r\n"));
     if (this.altscreen_state == AltScreenState.Active) {
       move_cursor(new_lines_this_flush, 0);
-    } else {
-      // log("moved cursor")
-      cursor_back(this.#width);
-      // cursor_back(100);
-      // console.log(cursor_back_seq(100))
     }
 
     this.#last_render = this.#buffer;


### PR DESCRIPTION
First, in order to use the bottom line of the screen, appending `"\r\n"` should not happen.
Second, resizes make `cursor.back(this.#width)` fail.
Finally, I don't think after resize it is known where the cursor is, so removing the text from the previous flush will start printing from an undefined place in the window.

Clearing the screen after a resize event from user/gleam code, results in a blank screen (it's cleared after the flush).

Given that at start-up of teashop, we start printing at the top left, `clear()` guarantees we always start printing at the top left. It's simpler, more predictable, and I surmise, the behaviour that users want.

Note: I left the branch with AltScreen in place, as I have no idea what that is.

Note: `gleam test` did not even compile - that's the point where I stop bothering.